### PR TITLE
Cleanly exit logstash if ZeroMQ raises exception

### DIFF
--- a/lib/logstash/inputs/zeromq.rb
+++ b/lib/logstash/inputs/zeromq.rb
@@ -114,8 +114,12 @@ class LogStash::Inputs::ZeroMQ < LogStash::Inputs::Base
   end # def register
 
   def close
-    error_check(@zsocket.close, "while closing the zmq socket")
-    context.terminate
+    begin
+      error_check(@zsocket.close, "while closing the zmq socket")
+      context.terminate
+    rescue RuntimeError => e
+      @logger.error("Failed to properly teardown ZeroMQ")
+    end
   end # def close
 
   def server?


### PR DESCRIPTION
There are irregularly situations where ZeroMQ raises an exception on
close. There is no need to stop logstash with RuntimeError and
stack backtrace if logstash is already tearing down.

The problem seems to be logstash closing an already closed ZeroMQ
socket.
